### PR TITLE
Fix: set permissions and KUBECONFIG variable (temp) for specific non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ $KSHOST with FQDN of node
 
 $NODE with ControlPlane or Worker
 
+Recommend VMs with at least 4GB disk free at /var +3.5GB of RAM
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Spin up Kubernetes master and worker node for Red Hat Linux family
 
+control plane+worker node
+
+metrics
+
+Cillium eBPF without kube-proxy as CNI
+
 for k8s > 1.29
 
 Tested with: 
@@ -9,6 +15,8 @@ Rocky 9
 Alma 9
 K8s 1.29.3
 containerd 1.6.28
+Calico
+Cillium+eBPF
 
 For now, edit the script and fill in:
 

--- a/k8s.sh
+++ b/k8s.sh
@@ -7,23 +7,23 @@
 # FQDN name of node to be installed
 # KSHOST="k8sm01"
 
-# ---
-# Example utilising external variables ${node_name} and ${count}
-NODE=${node_name}
-COUNT=${count}
-# #
-KSHOST="k8s-$NODE-$COUNT"
-# ---
+# # ---
+# # Example utilising external variables ${node_name} and ${count}
+# NODE=${node_name}
+# COUNT=${count}
+# # #
+# KSHOST="k8s-$NODE-$COUNT"
+# # ---
 
 CONTAINERD_CONFIG="/etc/containerd/config.toml"
 KUBEADM_CONFIG="/opt/k8s/kubeadm-config.yaml"
 
-DisableSELinux()
-{
-    # Disable SELinux
-    sudo setenforce 0
-    sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-}
+# DisableSELinux()
+# {
+#     # Disable SELinux
+#     sudo setenforce 0
+#     sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+# }
 
 GetIP()
 {
@@ -330,7 +330,7 @@ main()
         exit 1
     fi
 
-    DisableSELinux
+#     DisableSELinux
 
     GetIP
     SetupNodeName

--- a/k8s.sh
+++ b/k8s.sh
@@ -263,6 +263,12 @@ InstallHelm()
     curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s
 }
 
+Installk9s()
+{
+    sudo dnf -y copr enable luminoso/k9s
+    sudo dnf -y install k9s
+}
+
 Metrics()
 {
     kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
@@ -294,6 +300,8 @@ main()
     fi
 
     InstallHelm
+
+    Installk9s
 
     KubeadmConfig
     LaunchMaster

--- a/k8s.sh
+++ b/k8s.sh
@@ -43,6 +43,11 @@ InstallOSPackages()
     sudo dnf install -y jq wget curl tar vim firewalld yum-utils ca-certificates gnupg ipset ipvsadm iproute-tc git net-tools bind-utils
 }
 
+KernelRebootWhenPanic()
+{
+    sudo grubby --update-kernel=ALL --args="panic=60"
+}
+
 SetupFirewall()
 {
     # Prerequisites for kubeadm
@@ -296,6 +301,7 @@ main()
     SetupNodeName
     InstallVmWare
     InstallOSPackages
+    KernelRebootWhenPanic
     SetupFirewall
     SystemSettings
     LogLevelError

--- a/k8s.sh
+++ b/k8s.sh
@@ -228,7 +228,6 @@ apiServer:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-address: $IPADDR
 cgroupDriver: systemd
 authentication:
   anonymous:

--- a/k8s.sh
+++ b/k8s.sh
@@ -48,6 +48,16 @@ KernelRebootWhenPanic()
     sudo grubby --update-kernel=ALL --args="panic=60"
 }
 
+# Reboot if hanged
+SetupWatchdog()
+{
+    sudo dnf -y install watchdog
+    echo softdog | sudo tee /etc/modules-load.d/softdog.conf
+    sudo modprobe softdog
+    sudo sed 's/#watchdog-device/watchdog-device/g;s/#file/file/g;s/#change/change/g' /etc/watchdog.conf
+    sudo systemctl --now enable watchdog.service
+}
+
 SetupFirewall()
 {
     # Prerequisites for kubeadm
@@ -302,6 +312,7 @@ main()
     InstallVmWare
     InstallOSPackages
     KernelRebootWhenPanic
+    SetupWatchdog
     SetupFirewall
     SystemSettings
     LogLevelError

--- a/k8s.sh
+++ b/k8s.sh
@@ -102,6 +102,7 @@ EOF1
    sudo modprobe br_netfilter
 
    sudo mkdir -p /etc/sysctl.d/
+
    cat <<EOF2 | sudo tee /etc/sysctl.d/k8s.conf
 net.bridge.bridge-nf-call-iptables  = 1
 net.bridge.bridge-nf-call-ip6tables = 1
@@ -123,6 +124,7 @@ InstallK8s()
 {
     # Install Kubernetes
     LATEST_RELEASE=$(curl -sSL https://dl.k8s.io/release/stable.txt | sed 's/\(\.[0-9]*\)\.[0-9]*/\1/')
+
     cat <<EOF3 | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
@@ -143,6 +145,7 @@ LogLevelError()
     # make systemd only log warning level or greater
     # it will have less logs
     sudo mkdir -p /etc/systemd/system.conf.d/
+
     cat <<EOF4 | sudo tee /etc/systemd/system.conf.d/10-supress-loginfo.conf
 [Manager]
 LogLevel=warning
@@ -229,7 +232,10 @@ CNI()
     #kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
     helm repo add cilium https://helm.cilium.io/
 #     helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=probe
-    helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=true
+    helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=true \
+    --set k8sServiceHost=$IPADDR \
+    --set k8sServicePort=6443
+
 }
 
 WaitForNodeUP()
@@ -305,6 +311,12 @@ InstallHelm()
     curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s
 }
 
+Installk9s()
+{
+    sudo dnf -y copr enable luminoso/k9s
+    sudo dnf -y install k9s
+}
+
 Metrics()
 {
     kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
@@ -340,6 +352,7 @@ main()
     fi
 
     InstallHelm
+    Installk9s()
 
     KubeadmConfig
     LaunchMaster

--- a/k8s.sh
+++ b/k8s.sh
@@ -274,10 +274,15 @@ CNI()
     CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
     GOOS=$(go env GOOS)
     GOARCH=$(go env GOARCH)
-    curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/"${CILIUM_CLI_VERSION}/cilium-${GOOS}-${GOARCH}".tar.gz{,.sha256sum}
-sha256sum --check cilium-"${GOOS}-${GOARCH}".tar.gz.sha256sum
-    sudo tar -C /usr/local/bin -xzvf cilium-"${GOOS}-${GOARCH}".tar.gz
-    rm cilium-"${GOOS}-${GOARCH}".tar.gz{,.sha256sum}
+
+#     Attempting to stay POSIX-compatible
+#     curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/"$CILIUM_CLI_VERSION/cilium-$GOOS-$GOARCH".tar.gz{,.sha256sum}
+    curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/"$CILIUM_CLI_VERSION/cilium-$GOOS-$GOARCH".tar.gz
+    curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/"$CILIUM_CLI_VERSION/cilium-$GOOS-$GOARCH".tar.gz.sha256sum
+
+    sha256sum --check cilium-"$GOOS-$GOARCH".tar.gz.sha256sum
+    sudo tar -C /usr/local/bin -xzvf cilium-"$GOOS-$GOARCH".tar.gz
+    rm cilium-"$GOOS-$GOARCH".tar.gz cilium-"$GOOS-$GOARCH".tar.gz.sha256sum
 
 
     helm repo add cilium https://helm.cilium.io/
@@ -357,6 +362,13 @@ HostsMessage()
 InstallHelm()
 {
     curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s
+
+    # Add the stable repository
+    helm repo add stable https://charts.helm.sh/stable
+    # Add the cilium repository
+    helm repo add cilium https://helm.cilium.io/
+    # Update your repositories
+    helm repo update
 }
 
 Installk9s()

--- a/k8s.sh
+++ b/k8s.sh
@@ -286,6 +286,7 @@ CNI()
 
 
     helm repo add cilium https://helm.cilium.io/
+#   command to dynamically get latest cilium cli release from helm: helm search repo cilium | awk 'NR==2{print $2}'
     helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=true  --set k8sServiceHost="$IPADDR" --set k8sServicePort=6443
 
     cilium status —wait

--- a/k8s.sh
+++ b/k8s.sh
@@ -29,7 +29,8 @@ KUBEADM_CONFIG="/opt/k8s/kubeadm-config.yaml"
 GetIP()
 {
     # Get primary IP address
-    IPADDR=$(ip addr show dev eth0 | grep 'inet ' | awk '{print $2}' | cut -d '/' -f 1)
+    IPADDR=$(ip -o addr show up primary scope global |
+      while read -r num dev fam addr rest; do echo ${addr%/*}; done | head -1)
 }
 
 SetupNodeName()

--- a/k8s.sh
+++ b/k8s.sh
@@ -35,16 +35,16 @@ GetIP()
 SetupNodeName()
 {
     # Set hostname
-    sudo hostnamectl set-hostname $KSHOST
+    sudo hostnamectl set-hostname "$KSHOST"
     echo "$IPADDR $KSHOST" | sudo tee -a /etc/hosts
 }
 
 InstallVmWare()
 {
     sudo dnf -y install virt-what
-    if [[ $(sudo virt-what) = "vmware" ]]
+    if [ "$(sudo virt-what)" = "vmware" ]
     then
-        sudo rpm -e microcode_ctl $(rpm -q -a | grep firmware)
+        sudo rpm -e microcode_ctl "$(rpm -q -a | grep firmware)"
         sudo dnf -y install open-vm-tools
     fi
 }
@@ -158,7 +158,7 @@ InterfaceWithcontainerd()
 {
     # Replace default pause image version in containerd with kubeadm suggested version
     # However, the default containerd pause image version is supposed to be able to overwrite what kubeadm suggests
-    LATEST_PAUSE_VERSION=$(kubeadm config images list --kubernetes-version=$(kubeadm version -o short) | grep pause | cut -d ':' -f 2)
+    LATEST_PAUSE_VERSION=$(kubeadm config images list --kubernetes-version="$(kubeadm version -o short)" | grep pause | cut -d ':' -f 2)
 
     # Construct the full image name with registry prefix
     sudo sed -i "s/\(sandbox_image = .*\:\)\(.*\)\"/\1$LATEST_PAUSE_VERSION\"/" $CONTAINERD_CONFIG
@@ -233,7 +233,7 @@ CNI()
     helm repo add cilium https://helm.cilium.io/
 #     helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=probe
     helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=true \
-    --set k8sServiceHost=$IPADDR \
+    --set k8sServiceHost="$IPADDR" \
     --set k8sServicePort=6443
 
 }
@@ -345,14 +345,14 @@ main()
     InstallK8s
     InterfaceWithcontainerd
 
-    if [ $NODE = "worker" ]
+    if [ "$NODE" = "worker" ]
     then
         HostsMessage
         exit 0
     fi
 
     InstallHelm
-    Installk9s()
+    Installk9s
 
     KubeadmConfig
     LaunchMaster

--- a/k8s.sh
+++ b/k8s.sh
@@ -2,7 +2,7 @@
 
 # Can be controlplane or worker
 # NODE="controlplane"
-# NODE="Worker"
+# NODE="worker"
 
 # FQDN name of node to be installed
 KSHOST=""

--- a/k8s.sh
+++ b/k8s.sh
@@ -286,7 +286,7 @@ CNI()
 
 
     helm repo add cilium https://helm.cilium.io/
-#   command to dynamically get latest cilium cli release from helm: helm search repo cilium | awk 'NR==2{print $2}'
+#   sample command to dynamically get latest cilium cli release from helm: helm search repo cilium | awk 'NR==2{print $2}'
     helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=true  --set k8sServiceHost="$IPADDR" --set k8sServicePort=6443
 
     cilium status —wait

--- a/k8s.sh
+++ b/k8s.sh
@@ -7,25 +7,25 @@
 # FQDN name of node to be installed
 # KSHOST="k8sm01"
 
-# # ---
-# # Example utilising external variables ${node_name} and ${count}
-# NODE=${node_name}
-# COUNT=${count}
-# # #
-# KSHOST="k8s-$NODE-$COUNT"
-# # ---
+# ---
+# Example utilising external variables ${node_name} and ${count}
+NODE=${node_name}
+COUNT=${count}
+# #
+KSHOST="k8s-$NODE-$COUNT"
+# ---
 
 CONTAINERD_CONFIG="/etc/containerd/config.toml"
 KUBEADM_CONFIG="/opt/k8s/kubeadm-config.yaml"
 
-DontRunAsRoot()
-{
-    if [ $(id -u) -eq 0 ]
-    then
-        echo "This script is not meant to be run with sudo/root privileges"
-        exit 1
-    fi
-}
+# DontRunAsRoot()
+# {
+#     if [ $(id -u) -eq 0 ]
+#     then
+#         echo "This script is not meant to be run with sudo/root privileges"
+#         exit 1
+#     fi
+# }
 
 # DisableSELinux()
 # {
@@ -344,7 +344,7 @@ main()
         exit 1
     fi
 
-    DontRunAsRoot
+#     DontRunAsRoot
 
 #     DisableSELinux
 

--- a/k8s.sh
+++ b/k8s.sh
@@ -316,7 +316,8 @@ LaunchMaster()
 #     sudo cp -f /etc/kubernetes/admin.conf "$HOME"/.kube/config
 #     sudo chown "$(id -u $USER)":"$(id -g $USER)" "$HOME"/.kube/config
 
-    USER="ec2-user" # AWS-specific, DO NOT USE IN PRODUCTION
+#     USER="ec2-user" # AWS-specific, DO NOT USE IN PRODUCTION
+    USER=""
     HOME_DIR=$(getent passwd "$USER" | awk -F ':' '{print $6}')
     mkdir -p "$HOME_DIR"/.kube/
     cp -f /etc/kubernetes/admin.conf "$HOME_DIR"/.kube/config

--- a/k8s.sh
+++ b/k8s.sh
@@ -443,7 +443,7 @@ main()
         exit 1
     fi
 
-#     DontRunAsRoot
+    DontRunAsRoot
 
 #     DisableSELinux
 

--- a/k8s.sh
+++ b/k8s.sh
@@ -24,6 +24,15 @@ SetupNodeName()
     echo "$IPADDR $KSHOST" | sudo tee -a /etc/hosts
 }
 
+InstallVmWare()
+{
+    sudo dnf -y install virt-what
+    if [[ $(sudo virt-what) = "vmware" ]]
+    then
+        sudo rpm -e microcode_ctl $(rpm -q -a | grep firmware)
+        sudo dnf -y install open-vm-tools
+    fi
+}
 
 InstallOSPackages()
 {
@@ -285,6 +294,7 @@ main()
 
     GetIP
     SetupNodeName
+    InstallVmWare
     InstallOSPackages
     SetupFirewall
     SystemSettings

--- a/k8s.sh
+++ b/k8s.sh
@@ -285,6 +285,7 @@ CNI()
     rm cilium-"$GOOS-$GOARCH".tar.gz cilium-"$GOOS-$GOARCH".tar.gz.sha256sum
 
 
+#   add the cilium repository
     helm repo add cilium https://helm.cilium.io/
 #   sample command to dynamically get latest cilium cli release from helm: helm search repo cilium | awk 'NR==2{print $2}'
     helm install cilium cilium/cilium --version 1.15.3 --namespace kube-system --set kubeProxyReplacement=true  --set k8sServiceHost="$IPADDR" --set k8sServicePort=6443
@@ -363,13 +364,6 @@ HostsMessage()
 InstallHelm()
 {
     curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s
-
-    # Add the stable repository
-    helm repo add stable https://charts.helm.sh/stable
-    # Add the cilium repository
-    helm repo add cilium https://helm.cilium.io/
-    # Update your repositories
-    helm repo update
 }
 
 Installk9s()

--- a/k8s.sh
+++ b/k8s.sh
@@ -13,9 +13,9 @@ KSHOST=""
 #KSHOST="k8sw01" # example Worker node
 
 # Example utilising external variables ${node_name} and ${count}
-NODE=${node_name}
-COUNT=${count}
-KSHOST="k8s-$NODE-$COUNT"
+# NODE=${node_name}
+# COUNT=${count}
+# KSHOST="k8s-$NODE-$COUNT"
 
 # ----------------
 # VARIABLES

--- a/k8s.sh
+++ b/k8s.sh
@@ -27,7 +27,7 @@ PATH="$PATH":/usr/local/bin
 export PATH
 DontRunAsRoot()
 {
-    if [ $(id -u) -eq 0 ]
+    if [ "$(id -u)" -eq 0 ]
     then
         echo "This script is not meant to be run with sudo/root privileges"
         exit 1
@@ -61,7 +61,7 @@ InstallVmWare()
     sudo dnf -y install virt-what
     if [ "$(sudo virt-what)" = "vmware" ]
     then
-        sudo rpm -e microcode_ctl $(rpm -q -a | grep firmware)
+        sudo rpm -e microcode_ctl "$(rpm -q -a | grep firmware)"
         sudo dnf -y install open-vm-tools
     fi
 }
@@ -274,9 +274,9 @@ CNI()
     CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
     GOOS=$(go env GOOS)
     GOARCH=$(go env GOARCH)
-    curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/"${CILIUM_CLI_VERSION}/cilium-${GOOS}-${GOARCH}".tar.gz
-    sudo tar -C /usr/local/bin -xzvf cilium-"${GOOS}-${GOARCH}".tar.gz
-    rm cilium-"${GOOS}-${GOARCH}".tar.gz
+    curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/"$CILIUM_CLI_VERSION/cilium-$GOOS-$GOARCH".tar.gz
+    sudo tar -C /usr/local/bin -xzvf cilium-"$GOOS-$GOARCH".tar.gz
+    rm cilium-"$GOOS-$GOARCH".tar.gz
 
     # add the cilium repository
     helm repo add cilium https://helm.cilium.io/


### PR DESCRIPTION
This fix should enable `k9s` and `kubectl` to function like normal again. Further testing warranted, of course.

This patch is necessary if script is run as root user (cloud-init instances in the Cloud). For regular operations, either comment out the section or input desired user as `$USER`.

Please let me know if this change creates issues/errors in your system. I will be going over this again shortly.

To note:

1. `$KADM_OPTIONS` has been uncommented to let script work as usual with the `kubeadm init` check.
2. The package `epel-release` is necessary to install `haveged`, although it seems that was not the original problem. Nice-to-have at the moment, will consider retention if required.
3. Round-about method to get the home directory of a user; TBH it was done because the more obvious techniques like `/home/$USER` were mysteriously failing. This will take into account "custom" home pathnames, but it is hacky. To consider refactoring at a later stage.
4. Additional `kubelet` configuration section in the `kubeadm` config template block. Should not affect operations, was specifically for minor `kubelet` issues I was facing. Does not have hard-coded tokens/certificates, however it might present a security risk. *Needs approval*.
5. `DontRunasRoot` check has been disabled, will be re-enabled in the coming commit.

Thanks, please let me know if there are any issues.