### PR TITLE
fix: KUBECONFIG variable appended to for k8s components to work; refactor

### DIFF
--- a/k8s.sh
+++ b/k8s.sh
@@ -324,7 +324,7 @@ LaunchMaster()
     chown "$(id -u $USER)":"$(id -g $USER)" "$HOME_DIR"/.kube/config
 
 #   https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#append-home-kube-config-to-your-kubeconfig-environment-variable
-    export KUBECONFIG="${KUBECONFIG}":"$HOME_DIR"/.kube/config
+    export KUBECONFIG="$KUBECONFIG":"$HOME_DIR"/.kube/config
 
 #    # Alternatively, if one is a root user, run this:
 #     export KUBECONFIG=/etc/kubernetes/admin.conf

--- a/k8s.sh
+++ b/k8s.sh
@@ -316,6 +316,7 @@ LaunchMaster()
 #     sudo chown "$(id -u $USER)":"$(id -g $USER)" "$HOME"/.kube/config
 
 #     USER="ec2-user" # AWS-specific, DO NOT USE IN PRODUCTION
+#     USER=id -un # Get user running the script
 
     HOME_DIR=$(getent passwd "$USER" | awk -F ':' '{print $6}')
     mkdir -p "$HOME_DIR"/.kube/

--- a/k8s.sh
+++ b/k8s.sh
@@ -322,7 +322,9 @@ LaunchMaster()
     mkdir -p "$HOME_DIR"/.kube/
     cp -f /etc/kubernetes/admin.conf "$HOME_DIR"/.kube/config
     chown "$(id -u $USER)":"$(id -g $USER)" "$HOME_DIR"/.kube/config
-    #export KUBECONFIG="$HOME_DIR"/.kube/config
+
+#   https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#append-home-kube-config-to-your-kubeconfig-environment-variable
+    export KUBECONFIG="${KUBECONFIG}":"$HOME_DIR"/.kube/config
 
 #    # Alternatively, if one is a root user, run this:
 #     export KUBECONFIG=/etc/kubernetes/admin.conf


### PR DESCRIPTION
From: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#append-home-kube-config-to-your-kubeconfig-environment-variable

`k8s` documentation states that the `KUBECONFIG` variable should be appended to if the value `$HOME/.kube/config` is not present in it. Considering my circumstances (running as root), that is exactly the case.

Either way, this is a good default to have - perhaps a check to see if `$HOME/.kube/config` is already present in `KUBECONFIG` is a good idea. This effectively solves most `kubectl` and `k9s` issues.

Also, refactoring.